### PR TITLE
feat: add new diploma layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,6 +1,8 @@
 :root {
   --bg: #FFE667;
-  --blue: #0C00C0;
+  --azul: #0C00C0;
+  --verde: #a8de73;
+  --franja: #1B2C98;
   --white: #FFFFFF;
 }
 
@@ -27,8 +29,8 @@ body {
   padding: 0.5rem 1rem;
   border-radius: 4px;
   cursor: pointer;
-  border: 1px solid var(--blue);
-  color: var(--blue);
+  border: 1px solid var(--azul);
+  color: var(--azul);
   margin-bottom: 0.5rem;
 }
 .file-input input {
@@ -41,7 +43,7 @@ body {
 }
 
 button {
-  background: var(--blue);
+  background: var(--azul);
   color: var(--white);
   border: none;
   border-radius: 4px;
@@ -62,52 +64,128 @@ button:hover {
   background: var(--white);
   box-shadow: 0 0 5px rgba(0,0,0,0.2);
   margin: 0 auto;
+  position: relative;
+  overflow: hidden;
+}
+
+.left-bar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 45mm;
+  height: 100%;
+  background: var(--franja);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.left-text {
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  text-align: center;
+  color: var(--verde);
+  font-family: 'FF Nort Headline', sans-serif;
+}
+
+.left-text .big {
+  font-size: 32pt;
+  font-weight: bold;
+}
+
+.left-text .small {
+  font-size: 20pt;
+  font-style: italic;
+}
+
+.top-logos {
+  position: absolute;
+  top: 20mm;
+  right: 20mm;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+.logo-pacifico {
+  width: 60mm;
+}
+
+.logo-crea {
+  width: 30mm;
+  margin-top: 5mm;
+}
+
+.content {
+  margin-left: 55mm;
   padding: 20mm;
   box-sizing: border-box;
-  position: relative;
+  text-align: center;
+  color: var(--azul);
 }
 
-.logo {
-  width: 60mm;
-  display: block;
-  margin: 0 auto 10mm;
-}
-
-.title {
-  font-family: 'FF Nort Headline', sans-serif;
-  color: var(--blue);
-  font-size: 32pt;
-  margin: 0 0 5mm;
-}
-
-.subtitle {
-  font-size: 14pt;
+.intro {
+  font-size: 16pt;
   margin: 0;
+}
+
+.name-container {
+  margin: 10mm auto;
+  width: 120mm;
 }
 
 .name {
   font-family: 'FF Nort Headline', sans-serif;
-  font-size: 28pt;
-  margin: 10mm 0;
+  color: var(--verde);
+  margin: 0;
+  text-transform: uppercase;
+  line-height: 1.1;
 }
 
-.course, .hours, .area {
+.name-underline {
+  border-bottom: 2px solid var(--azul);
+  margin-top: 4mm;
+}
+
+.taller-text {
   font-size: 14pt;
-  margin: 3mm 0;
+  margin: 10mm auto;
+  width: 80%;
 }
 
-.footer {
-  position: absolute;
-  bottom: 20mm;
-  left: 0;
-  width: 100%;
+.signatures {
   display: flex;
-  justify-content: space-between;
-  font-size: 12pt;
+  justify-content: space-around;
+  margin-top: 20mm;
 }
-.firmante {
-  border-top: 1px solid #000;
-  padding-top: 2mm;
+
+.signature {
+  width: 40%;
+  text-align: center;
+  color: var(--azul);
+}
+
+.firma-img {
+  height: 30mm;
+}
+
+.firma-line {
+  border-bottom: 2px solid var(--azul);
+  margin: -5mm auto 4mm;
+}
+
+.firma-name {
+  font-weight: bold;
+  margin: 0;
+}
+
+.firma-role {
+  margin: 0;
+}
+
+.note {
+  font-size: 10pt;
+  margin-top: 20mm;
 }
 
 @media (max-width: 800px) {

--- a/index.html
+++ b/index.html
@@ -32,16 +32,38 @@
 
     <div id="preview">
       <section id="diploma" class="diploma">
-        <img src="simbolo.svg" alt="Logo" class="logo">
-        <h2 class="title">Diploma</h2>
-        <p class="subtitle">Otorgado a</p>
-        <h3 id="nombre" class="name"></h3>
-        <p class="course">Por completar el curso <span id="curso"></span></p>
-        <p class="hours">Duración: <span id="horas"></span></p>
-        <p class="area">Área: <span id="area"></span></p>
-        <div class="footer">
-          <span id="firmante" class="firmante"></span>
-          <span id="fecha" class="fecha"></span>
+        <div class="left-bar">
+          <div class="left-text">
+            <span class="big">DIPLOMA</span>
+            <span class="small">De Participación</span>
+          </div>
+        </div>
+        <div class="top-logos">
+          <img src="PACIFICO SEGURO LOGO.png" alt="Pacífico Seguro" class="logo-pacifico">
+          <img src="sello crea+.PNG" alt="Crea+" class="logo-crea">
+        </div>
+        <div class="content">
+          <p class="intro">Crea+ felicita a:</p>
+          <div class="name-container">
+            <h3 id="nombre" class="name"></h3>
+            <div class="name-underline"></div>
+          </div>
+          <p class="taller-text">Por su participación en el taller <span id="taller"></span> facilitado por <span id="facilitador"></span>.</p>
+          <div class="signatures">
+            <div class="signature">
+              <img src="Firma diego.PNG" alt="Firma Diego" class="firma-img">
+              <div class="firma-line"></div>
+              <p class="firma-name">Diego [Nombre]</p>
+              <p class="firma-role">Cargo 1</p>
+            </div>
+            <div class="signature">
+              <img src="Firma 2.PNG" alt="Firma 2" class="firma-img">
+              <div class="firma-line"></div>
+              <p class="firma-name">Nombre 2</p>
+              <p class="firma-role">Cargo 2</p>
+            </div>
+          </div>
+          <p class="note">Este diploma es válido solo con la firma de los responsables y el sello de Crea+.</p>
         </div>
       </section>
     </div>
@@ -97,11 +119,8 @@ async function loadExcel(file){
     if(!nombre) return null;
     return {
       nombre:nombre,
-      curso:row['curso']||'—',
-      horas:row['horas']||'—',
-      area:row['area']||'—',
-      fecha:formatDate(row['fecha'])||'—',
-      firmante:row['firmante']||'—'
+      taller:row['taller']||'—',
+      facilitador:row['facilitador']||'—'
     };
   }).filter(Boolean);
   document.getElementById('count').textContent=participants.length;
@@ -112,26 +131,24 @@ async function loadExcel(file){
 }
 
 /**
- * Convierte fechas a DD/MM/AAAA si es posible.
- */
-function formatDate(value){
-  if(!value) return '';
-  const date=new Date(value);
-  if(!isNaN(date)) return date.toLocaleDateString('es-PE');
-  return value;
-}
-
-/**
  * Renderiza el diploma en pantalla.
  */
 function renderDiploma(data){
   if(!data) return;
-  document.getElementById('nombre').textContent=data.nombre;
-  document.getElementById('curso').textContent=data.curso;
-  document.getElementById('horas').textContent=data.horas;
-  document.getElementById('area').textContent=data.area;
-  document.getElementById('fecha').textContent=data.fecha;
-  document.getElementById('firmante').textContent=data.firmante;
+  const nameEl=document.getElementById('nombre');
+  nameEl.textContent=data.nombre.toUpperCase();
+  fitText(nameEl, document.querySelector('.name-underline').offsetWidth);
+  document.getElementById('taller').textContent=data.taller;
+  document.getElementById('facilitador').textContent=data.facilitador;
+}
+
+function fitText(el,width){
+  let size=60;
+  el.style.fontSize=size+'px';
+  while(el.scrollWidth>width && size>12){
+    size--;
+    el.style.fontSize=size+'px';
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- add left blue strip with vertical title and logos for Pacífico Seguro and Crea+
- render participant name, workshop and facilitator with dynamic font sizing
- style signatures and footer note for PDF output

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cffc13830832f82ce935fea50a775