### PR TITLE
Implement landscape diploma layout with dynamic course data

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2,7 +2,6 @@
   --bg: #FFE667;
   --azul: #0C00C0;
   --verde: #a8de73;
-  --franja: #1B2C98;
   --white: #FFFFFF;
 }
 
@@ -59,8 +58,8 @@ button:hover {
 }
 
 #diploma {
-  width: 210mm;
-  height: 297mm;
+  width: 297mm;
+  height: 210mm;
   background: var(--white);
   box-shadow: 0 0 5px rgba(0,0,0,0.2);
   margin: 0 auto;
@@ -69,15 +68,27 @@ button:hover {
 }
 
 .left-bar {
+  overflow: hidden;
   position: absolute;
   top: 0;
   left: 0;
-  width: 45mm;
+  width: 60mm;
   height: 100%;
-  background: var(--franja);
+  background: var(--azul);
   display: flex;
   justify-content: center;
   align-items: center;
+}
+
+.left-bar::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 40mm;
+  background: url("../assets/pattern-left.png") no-repeat top center;
+  background-size: cover;
 }
 
 .left-text {
@@ -117,7 +128,7 @@ button:hover {
 }
 
 .content {
-  margin-left: 55mm;
+  margin-left: 70mm;
   padding: 20mm;
   box-sizing: border-box;
   text-align: center;
@@ -131,7 +142,7 @@ button:hover {
 
 .name-container {
   margin: 10mm auto;
-  width: 120mm;
+  width: 160mm;
 }
 
 .name {
@@ -147,7 +158,7 @@ button:hover {
   margin-top: 4mm;
 }
 
-.taller-text {
+.curso-text {
   font-size: 14pt;
   margin: 10mm auto;
   width: 80%;
@@ -181,6 +192,13 @@ button:hover {
 
 .firma-role {
   margin: 0;
+}
+
+.sello {
+  position: absolute;
+  bottom: 20mm;
+  right: 20mm;
+  width: 35mm;
 }
 
 .note {

--- a/index.html
+++ b/index.html
@@ -39,8 +39,8 @@
           </div>
         </div>
         <div class="top-logos">
-          <img src="PACIFICO SEGURO LOGO.png" alt="Pacífico Seguro" class="logo-pacifico">
-          <img src="sello crea+.PNG" alt="Crea+" class="logo-crea">
+          <img src="assets/pacifico-logo.png" alt="Pacífico Seguro" class="logo-pacifico">
+          <img src="assets/crea-simbolo.svg" alt="Crea+" class="logo-crea">
         </div>
         <div class="content">
           <p class="intro">Crea+ felicita a:</p>
@@ -48,23 +48,24 @@
             <h3 id="nombre" class="name"></h3>
             <div class="name-underline"></div>
           </div>
-          <p class="taller-text">Por su participación en el taller <span id="taller"></span> facilitado por <span id="facilitador"></span>.</p>
+          <p class="curso-text">Por su participación en el curso <span id="curso"></span> facilitado por <span id="facilitador"></span>.</p>
           <div class="signatures">
             <div class="signature">
-              <img src="Firma diego.PNG" alt="Firma Diego" class="firma-img">
+              <img src="assets/firma-diego.png" alt="Firma Diego" class="firma-img">
               <div class="firma-line"></div>
-              <p class="firma-name">Diego [Nombre]</p>
-              <p class="firma-role">Cargo 1</p>
+              <p class="firma-name">DIEGO CABRERA</p>
+              <p class="firma-role">Director de Cultura y Talento Humano</p>
             </div>
             <div class="signature">
-              <img src="Firma 2.PNG" alt="Firma 2" class="firma-img">
+              <img src="assets/firma-2.png" alt="Firma 2" class="firma-img">
               <div class="firma-line"></div>
-              <p class="firma-name">Nombre 2</p>
-              <p class="firma-role">Cargo 2</p>
+              <p class="firma-name">GABRIELA DENEGRI</p>
+              <p class="firma-role">Directora Ejecutiva</p>
             </div>
           </div>
           <p class="note">Este diploma es válido solo con la firma de los responsables y el sello de Crea+.</p>
-        </div>
+            <img src="assets/sello-crea.png" alt="Sello Crea+" class="sello">
+  </div>
       </section>
     </div>
   </main>
@@ -119,7 +120,7 @@ async function loadExcel(file){
     if(!nombre) return null;
     return {
       nombre:nombre,
-      taller:row['taller']||'—',
+      curso:row['curso']||'—',
       facilitador:row['facilitador']||'—'
     };
   }).filter(Boolean);
@@ -138,7 +139,7 @@ function renderDiploma(data){
   const nameEl=document.getElementById('nombre');
   nameEl.textContent=data.nombre.toUpperCase();
   fitText(nameEl, document.querySelector('.name-underline').offsetWidth);
-  document.getElementById('taller').textContent=data.taller;
+  document.getElementById('curso').textContent=data.curso;
   document.getElementById('facilitador').textContent=data.facilitador;
 }
 
@@ -158,8 +159,8 @@ async function downloadPDF(data){
   const diploma=document.getElementById('diploma');
   const canvas=await html2canvas(diploma,{scale:2});
   const img=canvas.toDataURL('image/png');
-  const pdf=new jspdf.jsPDF('p','mm','a4');
-  pdf.addImage(img,'PNG',0,0,210,297);
+  const pdf=new jspdf.jsPDF('l','mm','a4');
+  pdf.addImage(img,'PNG',0,0,297,210);
   pdf.save(`Diploma_${sanitize(data.nombre)}.pdf`);
 }
 


### PR DESCRIPTION
## Summary
- Style diploma for A4 landscape with blue sidebar pattern and repositioned logos
- Support course/facilitator fields from Excel and adjust PDF export orientation
- Add official signatures and Crea+ seal assets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d01be516c832f826ab1012be0ea15